### PR TITLE
Replace IsURL by IsWebAddress

### DIFF
--- a/types.go
+++ b/types.go
@@ -38,9 +38,22 @@ func IsHost(target string) bool {
 }
 
 // IsURL returns true if the target is an absolute URL (it has a non-empty scheme).
+//
+// This method is kept to don't break compatibility, use IsWebAddress instead.
 func IsURL(target string) bool {
+	return IsWebAddress(target)
+}
+
+// IsWebAddress returns true if the target is an absolute URL.
+//
+// - It has a non-empty scheme (http or https)
+// - It has a non-empty hostname
+func IsWebAddress(target string) bool {
 	u, err := url.ParseRequestURI(target)
-	return err == nil && u.IsAbs()
+	if err != nil {
+		return false
+	}
+	return u.IsAbs() && (u.Scheme == "https" || u.Scheme == "http") && u.Hostname() != ""
 }
 
 // IsAWSARN returns true if the target is an AWS ARN.

--- a/types_test.go
+++ b/types_test.go
@@ -136,7 +136,7 @@ func TestIsHost(t *testing.T) {
 	}
 }
 
-func TestIsURL(t *testing.T) {
+func TestIsWebAddress(t *testing.T) {
 	tests := []struct {
 		name   string
 		target string
@@ -146,6 +146,21 @@ func TestIsURL(t *testing.T) {
 			name:   "URL",
 			target: "http://127.0.0.1",
 			want:   true,
+		},
+		{
+			name:   "FTP",
+			target: "ftp://127.0.0.1",
+			want:   false,
+		},
+		{
+			name:   "URL with empty scheme (IP)",
+			target: "127.0.0.1:8080",
+			want:   false,
+		},
+		{
+			name:   "URL with empty scheme (Hostname)",
+			target: "localhost:8080",
+			want:   false,
 		},
 		{
 			name:   "Path",
@@ -166,7 +181,7 @@ func TestIsURL(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsURL(tt.target)
+			got := IsWebAddress(tt.target)
 			if got != tt.want {
 				t.Errorf("got %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
The purpose of IsURL was checking if a string was a web address
(http://www.adevinta.com) or not.

It was not working correctly because for example localhost:8080 was
being taken as a  valid absolute URL, and it was not its purpose.

We are adding are replacing the IsURL method by IsWebAddress but, in
order to not break existing integrations, the method IsURL will be kept
just encapusulating the new one.