### PR TITLE
Make docker img type verification compliant with registries V2 spec

### DIFF
--- a/types.go
+++ b/types.go
@@ -78,6 +78,8 @@ func IsAWSARN(target string) bool {
 //   Valid: registry.hub.docker.com/metasploitframework/metasploit-framework:latest
 //   Valid: registry.hub.docker.com/metasploitframework/metasploit-framework
 //   Valid: registry.hub.docker.com/library/debian
+//   Valid: registry.hub.docker.com/path1/path2/artifact (compliant with V2 spec)
+//   Valid: registry.hub.docker.com/artifact (compliant with V2 spec)
 //   Valid: localhost:5500/library/debian
 //   Not valid: metasploitframework/metasploit-framework:latest
 //   Not valid: metasploitframework/metasploit-framework
@@ -92,9 +94,7 @@ func IsDockerImage(target string) bool {
 		return false
 	}
 
-	p := reference.Path(n)
-	parts := strings.Split(p, "/")
-	return len(parts) == 2
+	return true
 }
 
 // IsDomainName returns true if a query to a domain server returns a SOA record for the

--- a/types_test.go
+++ b/types_test.go
@@ -216,6 +216,16 @@ func TestIsDockerImage(t *testing.T) {
 			want:   false,
 		},
 		{
+			name:   "3 parts path registry",
+			target: "registry.hub.docker.com/hdmoore/metasploitframework/metasploit-framework",
+			want:   true,
+		},
+		{
+			name:   "Single path registry",
+			target: "registry.hub.docker.com/metasploit-framework",
+			want:   true,
+		},
+		{
 			name:   "Path",
 			target: "/etc/passwd",
 			want:   false,


### PR DESCRIPTION
References: https://docs.docker.com/registry/spec/api/#overview

> Classically, repository names have always been two path components where each path component is less than 30 characters. The V2 registry API does not enforce this. The rules for a repository name are as follows:
> 
>     A repository name is broken up into path components. A component of a repository name must be at least one lowercase, alpha-numeric characters, optionally separated by periods, dashes or underscores. More strictly, it must match the regular expression [a-z0-9]+(?:[._-][a-z0-9]+)*.
>     If a repository name has two or more path components, they must be separated by a forward slash (“/”).
>     The total length of a repository name, including slashes, must be less than 256 characters.
> 
> These name requirements only apply to the registry API and should accept a superset of what is supported by other docker ecosystem components.