### PR TITLE
Add support for GCPProject asset type

### DIFF
--- a/types.go
+++ b/types.go
@@ -215,6 +215,32 @@ func IsHostname(target string) bool {
 	return len(r) > 0
 }
 
+// IsGCPProjectId returns true if the target is a GCP Project.
+//
+// The unique, user-assigned id of the project. It 1ust be 6 to 30 lowercase ASCII letters, digits, or hyphens.
+// It must start with a letter. Trailing hyphens are prohibited.
+//
+//	Valid: googleproject
+//	Valid: google-project
+//	Valid: google-project123
+//	Valid: google-123-project
+//	Not valid: googleProject
+//	Not valid: google_project
+//	Not valid: google-project-
+//	Not valid: 123-google-project
+func IsGCPProjectId(target string) bool {
+	if IsHostname(target) {
+		return false
+	}
+
+	matched, err := regexp.MatchString("^[a-z][-a-z0-9]{4,28}[a-z0-9]{1}$", target)
+
+	if err != nil {
+		return false
+	}
+	return matched
+}
+
 type AssetType string
 
 // Asset types for vulcan assets.

--- a/types.go
+++ b/types.go
@@ -215,9 +215,9 @@ func IsHostname(target string) bool {
 	return len(r) > 0
 }
 
-// IsGCPProjectId returns true if the target is a GCP Project.
+// IsGCPProjectID returns true if the target is a GCP Project.
 //
-// The unique, user-assigned id of the project. It 1ust be 6 to 30 lowercase ASCII letters, digits, or hyphens.
+// A GCP project id is the unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens.
 // It must start with a letter. Trailing hyphens are prohibited.
 //
 //	Valid: googleproject
@@ -228,11 +228,7 @@ func IsHostname(target string) bool {
 //	Not valid: google_project
 //	Not valid: google-project-
 //	Not valid: 123-google-project
-func IsGCPProjectId(target string) bool {
-	if IsHostname(target) {
-		return false
-	}
-
+func IsGCPProjectID(target string) bool {
 	matched, err := regexp.MatchString("^[a-z][-a-z0-9]{4,28}[a-z0-9]{1}$", target)
 
 	if err != nil {

--- a/types_test.go
+++ b/types_test.go
@@ -628,7 +628,7 @@ func TestIsHostname(t *testing.T) {
 	}
 }
 
-func TestIsGCPProjectId(t *testing.T) {
+func TestIsGCPProjectID(t *testing.T) {
 	tests := []struct {
 		name   string
 		target string
@@ -640,7 +640,7 @@ func TestIsGCPProjectId(t *testing.T) {
 			want:   true,
 		},
 		{
-			name:   "GCP Project ID length should not less than 6 characters",
+			name:   "GCP Project ID length should not be less than 6 characters",
 			target: "hello",
 			want:   false,
 		},
@@ -650,7 +650,7 @@ func TestIsGCPProjectId(t *testing.T) {
 			want:   true,
 		},
 		{
-			name:   "GCP Project ID length should be greater than 30 characters",
+			name:   "GCP Project ID length should not be greater than 30 characters",
 			target: "thalamus-instinct-teaching-bemadden-word",
 			want:   false,
 		},
@@ -670,7 +670,7 @@ func TestIsGCPProjectId(t *testing.T) {
 			want:   false,
 		},
 		{
-			name:   "GCP Project ID should only hyphens in symbols",
+			name:   "GCP Project ID can only have hyphens and symbols",
 			target: "feebly-chrome_belittle-eyebrow",
 			want:   false,
 		},
@@ -698,7 +698,7 @@ func TestIsGCPProjectId(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsGCPProjectId(tt.target)
+			got := IsGCPProjectID(tt.target)
 			if got != tt.want {
 				t.Errorf("got %v, want %v", got, tt.want)
 			}

--- a/types_test.go
+++ b/types_test.go
@@ -628,6 +628,84 @@ func TestIsHostname(t *testing.T) {
 	}
 }
 
+func TestIsGCPProjectId(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   bool
+	}{
+		{
+			name:   "GCP Project ID with length equal to or greater than 6 characters",
+			target: "rabbit",
+			want:   true,
+		},
+		{
+			name:   "GCP Project ID length should not less than 6 characters",
+			target: "hello",
+			want:   false,
+		},
+		{
+			name:   "GCP Project ID with length equal to or less than 30 characters",
+			target: "bagase-crucible-bubble-gorilla",
+			want:   true,
+		},
+		{
+			name:   "GCP Project ID length should be greater than 30 characters",
+			target: "thalamus-instinct-teaching-bemadden-word",
+			want:   false,
+		},
+		{
+			name:   "GCP Project ID should only contain lowercase ASCII letters",
+			target: "macabre-MONOXIDE-bluish-biped",
+			want:   false,
+		},
+		{
+			name:   "GCP Project ID should not start with numbers",
+			target: "007bond",
+			want:   false,
+		},
+		{
+			name:   "GCP Project ID should only end with letters or digits",
+			target: "inherent-derris-",
+			want:   false,
+		},
+		{
+			name:   "GCP Project ID should only hyphens in symbols",
+			target: "feebly-chrome_belittle-eyebrow",
+			want:   false,
+		},
+		{
+			name:   "AWS ARN Account",
+			target: "arn:aws:iam::123456789012:root",
+			want:   false,
+		},
+		{
+			name:   "IP Path Web Address",
+			target: "http://127.0.0.1/path/to/directory",
+			want:   false,
+		},
+		{
+			name:   "Docker Image",
+			target: "registry.hub.docker.com/metasploitframework/metasploit-framework",
+			want:   false,
+		},
+		{
+			name:   "WebAddress",
+			target: "http://localhost:1234/",
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsGCPProjectId(tt.target)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDetectAssetTypes(t *testing.T) {
 	var tests = []struct {
 		name           string


### PR DESCRIPTION
This change aims to add the support for `GCPProject` asset type. The helper function looks into the following naming rules for considering the provided asset type as the valid `GCPProject`:
- It must be 4 to 30 lowercase ASCII letters, digits, or hyphens
- It must start with a letter
- It must not have trailing hyphens