### PR TITLE
add a hostname verification function that doesn't do dns resolution

### DIFF
--- a/types.go
+++ b/types.go
@@ -215,6 +215,21 @@ func IsHostname(target string) bool {
 	return len(r) > 0
 }
 
+// IsHostnameNoDnsResolution returns true if the target is not an IP.
+func IsHostnameNoDnsResolution(target string) bool {
+	// If the target is an IP can not be a hostname.
+	if IsIP(target) {
+		return false
+	}
+
+	// We don't want to onboard TLDs to vulcan
+	if !strings.Contains(target, ".") {
+		return false
+	}
+
+	return true
+}
+
 // IsGCPProjectID returns true if the target is a GCP Project.
 //
 // A GCP project id is the unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens.

--- a/types.go
+++ b/types.go
@@ -215,8 +215,8 @@ func IsHostname(target string) bool {
 	return len(r) > 0
 }
 
-// IsHostnameNoDnsResolution returns true if the target is not an IP.
-func IsHostnameNoDnsResolution(target string) bool {
+// IsHostnameNoDNSResolution returns true if the target is not an IP.
+func IsHostnameNoDNSResolution(target string) bool {
 	// If the target is an IP can not be a hostname.
 	if IsIP(target) {
 		return false

--- a/types_test.go
+++ b/types_test.go
@@ -628,6 +628,45 @@ func TestIsHostname(t *testing.T) {
 	}
 }
 
+func TestIsHostnameNoDnsResolution(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:   "Domain",
+			target: "adevinta.com",
+			want:   true,
+		},
+		{
+			name:   "Hostname",
+			target: "www.adevinta.com",
+			want:   true,
+		},
+		{
+			name:   "IP",
+			target: "127.0.0.1",
+			want:   false,
+		},
+		{
+			name:   "Garbage",
+			target: "31337",
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsHostnameNoDnsResolution(tt.target)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsGCPProjectID(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/types_test.go
+++ b/types_test.go
@@ -628,7 +628,7 @@ func TestIsHostname(t *testing.T) {
 	}
 }
 
-func TestIsHostnameNoDnsResolution(t *testing.T) {
+func TestIsHostnameNoDNSResolution(t *testing.T) {
 	tests := []struct {
 		name    string
 		target  string
@@ -659,7 +659,7 @@ func TestIsHostnameNoDnsResolution(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsHostnameNoDnsResolution(tt.target)
+			got := IsHostnameNoDNSResolution(tt.target)
 			if got != tt.want {
 				t.Errorf("got %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
This adds a hostname check that doesn't do a dns verification of the hostname, in order to support the use case of tracking assets that are behind a split horizon dns setup.

This is part 1 of 2, the other part will be in vulcan-api and use this function.

