### PR TITLE
go.mod, vulcan-types: use github.com/distribution/reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,13 @@ module github.com/adevinta/vulcan-types
 go 1.18
 
 require (
-	github.com/aws/aws-sdk-go v1.51.0
-	github.com/docker/distribution v2.8.3+incompatible
+	github.com/aws/aws-sdk-go v1.51.30
+	github.com/distribution/reference v0.6.0
 	github.com/google/go-cmp v0.6.0
 	github.com/miekg/dns v1.1.59
 )
 
 require (
-	github.com/distribution/reference v0.5.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	golang.org/x/mod v0.16.0 // indirect
 	golang.org/x/net v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
-github.com/aws/aws-sdk-go v1.51.0 h1:EA6GlEYMT3ouCO+v+oTWzKB/vcoHD2T9H9qulRx3lPg=
-github.com/aws/aws-sdk-go v1.51.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
-github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
-github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
-github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/aws/aws-sdk-go v1.51.30 h1:RVFkjn9P0JMwnuZCVH0TlV5k9zepHzlbc4943eZMhGw=
+github.com/aws/aws-sdk-go v1.51.30/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/miekg/dns v1.1.59 h1:C9EXc/UToRwKLhK5wKU/I4QVsBUc8kE6MkHBkeypWZs=

--- a/types.go
+++ b/types.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 	"github.com/miekg/dns"
 )
 


### PR DESCRIPTION
github.com/docker/distribution/reference [has been deprecated][1]. Use
github.com/distribution/reference instead. Also, upgrade all direct
dependencies to the latest version.

[1]: https://github.com/distribution/distribution/commit/6999f230d18e4da3880621456c19c8d4d3b6592e